### PR TITLE
[FaceAPI] Update Face samples to use detection_02 model

### DIFF
--- a/app-samples/Cognitive-Services-Face-WPF/Sample-WPF/Controls/FaceDetectionPage.xaml.cs
+++ b/app-samples/Cognitive-Services-Face-WPF/Sample-WPF/Controls/FaceDetectionPage.xaml.cs
@@ -65,11 +65,6 @@ namespace Microsoft.ProjectOxford.Face.Controls
         private static readonly string recognitionModel = RecognitionModel.Recognition02;
 
         /// <summary>
-        /// DetectionModel for Face detection
-        /// </summary>
-        private static readonly string detectionModel = DetectionModel.Detection02;
-
-        /// <summary>
         /// Face detection results in list container
         /// </summary>
         private ObservableCollection<Face> _detectedFaces = new ObservableCollection<Face>();
@@ -310,8 +305,7 @@ namespace Microsoft.ProjectOxford.Face.Controls
                                 FaceAttributeType.Occlusion,
                                 FaceAttributeType.Smile
                             },
-                            recognitionModel,
-                            detectionModel: detectionModel
+                            recognitionModel
                         );
 
                         MainWindow.Log("Response: Success. Detected {0} face(s) in {1}", faces.Count, pickedImagePath);

--- a/app-samples/Cognitive-Services-Face-WPF/Sample-WPF/Controls/FaceDetectionPage.xaml.cs
+++ b/app-samples/Cognitive-Services-Face-WPF/Sample-WPF/Controls/FaceDetectionPage.xaml.cs
@@ -65,6 +65,11 @@ namespace Microsoft.ProjectOxford.Face.Controls
         private static readonly string recognitionModel = RecognitionModel.Recognition02;
 
         /// <summary>
+        /// DetectionModel for Face detection
+        /// </summary>
+        private static readonly string detectionModel = DetectionModel.Detection02;
+
+        /// <summary>
         /// Face detection results in list container
         /// </summary>
         private ObservableCollection<Face> _detectedFaces = new ObservableCollection<Face>();
@@ -305,7 +310,8 @@ namespace Microsoft.ProjectOxford.Face.Controls
                                 FaceAttributeType.Occlusion,
                                 FaceAttributeType.Smile
                             },
-                            recognitionModel
+                            recognitionModel,
+                            detectionModel: detectionModel
                         );
 
                         MainWindow.Log("Response: Success. Detected {0} face(s) in {1}", faces.Count, pickedImagePath);

--- a/app-samples/Cognitive-Services-Face-WPF/Sample-WPF/Controls/FaceFindSimilarPage.xaml.cs
+++ b/app-samples/Cognitive-Services-Face-WPF/Sample-WPF/Controls/FaceFindSimilarPage.xaml.cs
@@ -69,6 +69,11 @@ namespace Microsoft.ProjectOxford.Face.Controls
         private static readonly string recognitionModel = RecognitionModel.Recognition02;
 
         /// <summary>
+        /// DetectionModel for Face detection
+        /// </summary>
+        private static readonly string detectionModel = DetectionModel.Detection02;
+
+        /// <summary>
         /// Faces collection which will be used to find similar from
         /// </summary>
         private ObservableCollection<Face> _facesCollection = new ObservableCollection<Face>();
@@ -255,7 +260,7 @@ namespace Microsoft.ProjectOxford.Face.Controls
                 {
                     MainWindow.Log("Request: Detecting faces in {0}", SelectedFile);
                     var faceServiceClient = FaceServiceClientHelper.GetInstance(this);
-                    IList<DetectedFace> faces = await faceServiceClient.Face.DetectWithStreamAsync(fStream, recognitionModel: recognitionModel);
+                    IList<DetectedFace> faces = await faceServiceClient.Face.DetectWithStreamAsync(fStream, recognitionModel: recognitionModel, detectionModel: detectionModel);
 
                     // Update detected faces on UI
                     foreach (var face in UIHelper.CalculateFaceRectangleForRendering(faces, MaxImageSize, imageInfo))
@@ -456,7 +461,7 @@ namespace Microsoft.ProjectOxford.Face.Controls
                                 try
                                 {
                                     var faces =
-                                        await faceServiceClient.LargeFaceList.AddFaceFromStreamAsync(_largeFaceListName, fStream);
+                                        await faceServiceClient.LargeFaceList.AddFaceFromStreamAsync(_largeFaceListName, fStream, detectionModel: detectionModel);
                                     return new Tuple<string, PersistedFace>(imgPath, faces);
                                 }
                                 catch (APIErrorException ex)

--- a/app-samples/Cognitive-Services-Face-WPF/Sample-WPF/Controls/FaceGroupingPage.xaml.cs
+++ b/app-samples/Cognitive-Services-Face-WPF/Sample-WPF/Controls/FaceGroupingPage.xaml.cs
@@ -66,6 +66,11 @@ namespace Microsoft.ProjectOxford.Face.Controls
         private static readonly string recognitionModel = RecognitionModel.Recognition02;
 
         /// <summary>
+        /// DetectionModel for Face detection
+        /// </summary>
+        private static readonly string detectionModel = DetectionModel.Detection02;
+
+        /// <summary>
         /// Faces to group
         /// </summary>
         private ObservableCollection<Face> _faces = new ObservableCollection<Face>();
@@ -185,7 +190,7 @@ namespace Microsoft.ProjectOxford.Face.Controls
                             {
                                 try
                                 {
-                                    var faces = await faceServiceClient.Face.DetectWithStreamAsync(fStream, recognitionModel: recognitionModel);
+                                    var faces = await faceServiceClient.Face.DetectWithStreamAsync(fStream, recognitionModel: recognitionModel, detectionModel: detectionModel);
                                     return new Tuple<string, IList<DetectedFace>>(imgPath, faces);
                                 }
                                 catch (APIErrorException ex)

--- a/app-samples/Cognitive-Services-Face-WPF/Sample-WPF/Controls/FaceIdentificationPage.xaml.cs
+++ b/app-samples/Cognitive-Services-Face-WPF/Sample-WPF/Controls/FaceIdentificationPage.xaml.cs
@@ -69,6 +69,11 @@ namespace Microsoft.ProjectOxford.Face.Controls
         private static readonly string recognitionModel = RecognitionModel.Recognition02;
 
         /// <summary>
+        /// DetectionModel for Face detection
+        /// </summary>
+        private static readonly string detectionModel = DetectionModel.Detection02;
+
+        /// <summary>
         /// Temporary group name for create person database
         /// </summary>
         public static readonly string SampleGroupName = Guid.NewGuid().ToString();
@@ -321,7 +326,7 @@ namespace Microsoft.ProjectOxford.Face.Controls
                                     try
                                     {
                                         // Update person faces on server side
-                                        var persistFace = await faceServiceClient.LargePersonGroupPerson.AddFaceFromStreamAsync(GroupName, Guid.Parse(p.PersonId), fStream, imgPath);
+                                        var persistFace = await faceServiceClient.LargePersonGroupPerson.AddFaceFromStreamAsync(GroupName, Guid.Parse(p.PersonId), fStream, imgPath, detectionModel: detectionModel);
                                         return new Tuple<string, PersistedFace>(imgPath, persistFace);
                                     }
                                     catch (APIErrorException ex)
@@ -449,7 +454,7 @@ namespace Microsoft.ProjectOxford.Face.Controls
                 {
                     try
                     {
-                        var faces = await faceServiceClient.Face.DetectWithStreamAsync(fStream, recognitionModel: recognitionModel);
+                        var faces = await faceServiceClient.Face.DetectWithStreamAsync(fStream, recognitionModel: recognitionModel, detectionModel: detectionModel);
 
                         // Convert detection result into UI binding object for rendering
                         foreach (var face in UIHelper.CalculateFaceRectangleForRendering(faces, MaxImageSize, imageInfo))

--- a/app-samples/Cognitive-Services-Face-WPF/Sample-WPF/Controls/FaceVerificationPage.xaml.cs
+++ b/app-samples/Cognitive-Services-Face-WPF/Sample-WPF/Controls/FaceVerificationPage.xaml.cs
@@ -67,6 +67,11 @@ namespace Microsoft.ProjectOxford.Face.Controls
         private static readonly string recognitionModel = RecognitionModel.Recognition02;
 
         /// <summary>
+        /// DetectionModel for Face detection
+        /// </summary>
+        private static readonly string detectionModel = DetectionModel.Detection02;
+
+        /// <summary>
         /// Temporary group name for create person database
         /// </summary>
         public static readonly string SampleGroupName = Guid.NewGuid().ToString();
@@ -298,7 +303,7 @@ namespace Microsoft.ProjectOxford.Face.Controls
                     try
                     {
                         var faceServiceClient = FaceServiceClientHelper.GetInstance(this);
-                        var faces = await faceServiceClient.Face.DetectWithStreamAsync(fileStream, recognitionModel: recognitionModel);
+                        var faces = await faceServiceClient.Face.DetectWithStreamAsync(fileStream, recognitionModel: recognitionModel, detectionModel: detectionModel);
 
                         // Handle REST API calling error
                         if (faces == null)
@@ -362,7 +367,7 @@ namespace Microsoft.ProjectOxford.Face.Controls
                     try
                     {
                         var faceServiceClient = FaceServiceClientHelper.GetInstance(this);
-                        var faces = await faceServiceClient.Face.DetectWithStreamAsync(fileStream, recognitionModel: recognitionModel);
+                        var faces = await faceServiceClient.Face.DetectWithStreamAsync(fileStream, recognitionModel: recognitionModel, detectionModel: detectionModel);
 
                         // Handle REST API calling error
                         if (faces == null)
@@ -549,7 +554,7 @@ namespace Microsoft.ProjectOxford.Face.Controls
                                 {
                                     var persistFace =
                                         await
-                                            faceServiceClient.LargePersonGroupPerson.AddFaceFromStreamAsync(GroupName, Guid.Parse(Person.PersonId), fStream, imgPath);
+                                            faceServiceClient.LargePersonGroupPerson.AddFaceFromStreamAsync(GroupName, Guid.Parse(Person.PersonId), fStream, imgPath, detectionModel: detectionModel);
                                     return new Tuple<string, PersistedFace>(imgPath, persistFace);
                                 }
                                 catch (APIErrorException ex)
@@ -666,7 +671,7 @@ namespace Microsoft.ProjectOxford.Face.Controls
                     try
                     {
                         var faceServiceClient = FaceServiceClientHelper.GetInstance(this);
-                        var faces = await faceServiceClient.Face.DetectWithStreamAsync(fileStream, recognitionModel: recognitionModel);
+                        var faces = await faceServiceClient.Face.DetectWithStreamAsync(fileStream, recognitionModel: recognitionModel, detectionModel: detectionModel);
 
                         // Handle REST API calling error
                         if (faces == null)

--- a/app-samples/Cognitive-Services-Face-WPF/Sample-WPF/FaceAPI-WPF-Samples.csproj
+++ b/app-samples/Cognitive-Services-Face-WPF/Sample-WPF/FaceAPI-WPF-Samples.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ClientLibrary</RootNamespace>
     <AssemblyName>FaceAPI-WPF-Samples</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
@@ -52,8 +52,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.CognitiveServices.Vision.Face, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Azure.CognitiveServices.Vision.Face.2.4.0-preview\lib\net461\Microsoft.Azure.CognitiveServices.Vision.Face.dll</HintPath>
+    <Reference Include="Microsoft.Azure.CognitiveServices.Vision.Face, Version=2.5.0-preview.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Azure.CognitiveServices.Vision.Face.2.5.0-preview.1\lib\net461\Microsoft.Azure.CognitiveServices.Vision.Face.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Rest.ClientRuntime.2.3.19\lib\net461\Microsoft.Rest.ClientRuntime.dll</HintPath>

--- a/app-samples/Cognitive-Services-Face-WPF/Sample-WPF/packages.config
+++ b/app-samples/Cognitive-Services-Face-WPF/Sample-WPF/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.CognitiveServices.Vision.Face" version="2.4.0-preview" targetFramework="net461" />
+  <package id="Microsoft.Azure.CognitiveServices.Vision.Face" version="2.5.0-preview.1" targetFramework="net461" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net46" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net46" />

--- a/app-samples/FaceAPIHeadPoseSample/FaceAPIHeadPoseSample/FaceAPIHeadPoseSample.csproj
+++ b/app-samples/FaceAPIHeadPoseSample/FaceAPIHeadPoseSample/FaceAPIHeadPoseSample.csproj
@@ -37,8 +37,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.CognitiveServices.Vision.Face, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.CognitiveServices.Vision.Face.2.4.0-preview\lib\net461\Microsoft.Azure.CognitiveServices.Vision.Face.dll</HintPath>
+    <Reference Include="Microsoft.Azure.CognitiveServices.Vision.Face, Version=2.5.0-preview.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.CognitiveServices.Vision.Face.2.5.0-preview.1\lib\net461\Microsoft.Azure.CognitiveServices.Vision.Face.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.19\lib\net461\Microsoft.Rest.ClientRuntime.dll</HintPath>

--- a/app-samples/FaceAPIHeadPoseSample/FaceAPIHeadPoseSample/packages.config
+++ b/app-samples/FaceAPIHeadPoseSample/FaceAPIHeadPoseSample/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.CognitiveServices.Vision.Face" version="2.4.0-preview" targetFramework="net461" />
+  <package id="Microsoft.Azure.CognitiveServices.Vision.Face" version="2.5.0-preview.1" targetFramework="net461" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.19" targetFramework="net461" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.19" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />

--- a/app-samples/FaceApiSnapshotSample/FaceApiSnapshotSample/FaceApiSnapshotSample.csproj
+++ b/app-samples/FaceApiSnapshotSample/FaceApiSnapshotSample/FaceApiSnapshotSample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.Face" Version="2.4.0-preview" />
+    <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.Face" Version="2.5.0-preview.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/app-samples/FaceApiSnapshotSample/FaceApiSnapshotSample/Program.cs
+++ b/app-samples/FaceApiSnapshotSample/FaceApiSnapshotSample/Program.cs
@@ -31,6 +31,11 @@
         private static readonly string recognitionModel = RecognitionModel.Recognition02;
 
         /// <summary>
+        /// RecognitionModel for Face detection.
+        /// </summary>
+        private static readonly string detectionModel = DetectionModel.Detection02;
+
+        /// <summary>
         /// Source endpoint in East Asia Region.
         /// </summary>
         private const string SourceEastAsiaEndpoint = "https://southeastasia.api.cognitive.microsoft.com/";
@@ -181,7 +186,8 @@
                         await client.PersonGroupPerson.AddFaceFromStreamAsync(
                             personGroupId,
                             person.PersonId,
-                            fileStream);
+                            fileStream,
+                            detectionModel: detectionModel);
                     }
                 }
             }
@@ -234,7 +240,7 @@
         {
             using (var fileStream = new FileStream("data\\PersonGroup\\Daughter\\Daughter1.jpg", FileMode.Open, FileAccess.Read))
             {
-                var detectedFaces = await client.Face.DetectWithStreamAsync(fileStream, recognitionModel: recognitionModel);
+                var detectedFaces = await client.Face.DetectWithStreamAsync(fileStream, recognitionModel: recognitionModel, detectionModel: detectionModel);
 
                 var result = await client.Face.IdentifyAsync(detectedFaces.Select(face => face.FaceId).Where(faceId => faceId != null).Select(faceId => faceId.Value).ToList(), personGroupId);
                 Console.WriteLine("Test identify against PersonGroup");

--- a/app-samples/FaceApiSnapshotSample/FaceApiSnapshotSample/Program.cs
+++ b/app-samples/FaceApiSnapshotSample/FaceApiSnapshotSample/Program.cs
@@ -31,7 +31,7 @@
         private static readonly string recognitionModel = RecognitionModel.Recognition02;
 
         /// <summary>
-        /// RecognitionModel for Face detection.
+        /// DetectionModel for Face detection.
         /// </summary>
         private static readonly string detectionModel = DetectionModel.Detection02;
 

--- a/samples/Face/Common.cs
+++ b/samples/Face/Common.cs
@@ -13,10 +13,10 @@
         // Parameter `returnFaceId` of `DetectWithStreamAsync` must be set to `true` (by default) for recognition purpose.
         // The field `faceId` in returned `DetectedFace`s will be used in Face - Identify, Face - Verify, and Face - Find Similar.
         // It will expire 24 hours after the detection call.
-        internal static async Task<List<DetectedFace>> DetectFaces(IFaceClient faceClient, string imageUrl, string recognitionModel = RecognitionModel.Recognition01)
+        internal static async Task<List<DetectedFace>> DetectFaces(IFaceClient faceClient, string imageUrl, string recognitionModel = RecognitionModel.Recognition01, string detectionModel = DetectionModel.Detection01)
         {
             // Detect faces from image stream.
-            IList<DetectedFace> detectedFaces = await faceClient.Face.DetectWithUrlAsync(imageUrl, recognitionModel: recognitionModel);
+            IList<DetectedFace> detectedFaces = await faceClient.Face.DetectWithUrlAsync(imageUrl, recognitionModel: recognitionModel, detectionModel: detectionModel);
             if (detectedFaces == null || detectedFaces.Count == 0)
             {
                 throw new Exception($"No face detected from image `{imageUrl}`.");

--- a/samples/Face/Detection.cs
+++ b/samples/Face/Detection.cs
@@ -14,7 +14,9 @@
 
             IFaceClient client = new FaceClient(new ApiKeyServiceClientCredentials(key)) { Endpoint = endpoint };
             string recognitionModel = RecognitionModel.Recognition02;
-            string detectionModel = DetectionModel.Detection02;
+
+            // Leaving detection model set to Detection01 -> Face attributes are only supported with Detection01 model
+            string detectionModel = DetectionModel.Detection01;
 
             const string ImageUrlPrefix = "https://csdx.blob.core.windows.net/resources/Face/Images/";
             List<string> imageFileNames = new List<string>

--- a/samples/Face/Detection.cs
+++ b/samples/Face/Detection.cs
@@ -14,6 +14,7 @@
 
             IFaceClient client = new FaceClient(new ApiKeyServiceClientCredentials(key)) { Endpoint = endpoint };
             string recognitionModel = RecognitionModel.Recognition02;
+            string detectionModel = DetectionModel.Detection02;
 
             const string ImageUrlPrefix = "https://csdx.blob.core.windows.net/resources/Face/Images/";
             List<string> imageFileNames = new List<string>
@@ -50,7 +51,8 @@
                                                                 FaceAttributeType.Occlusion,
                                                                 FaceAttributeType.Smile
                                                             },
-                                                        recognitionModel: recognitionModel);
+                                                        recognitionModel: recognitionModel,
+                                                        detectionModel: detectionModel);
 
                 if (detectedFaces == null || detectedFaces.Count == 0)
                 {

--- a/samples/Face/FindSimilar.cs
+++ b/samples/Face/FindSimilar.cs
@@ -15,6 +15,7 @@
 
             IFaceClient client = new FaceClient(new ApiKeyServiceClientCredentials(key)) { Endpoint = endpoint };
             string recognitionModel = RecognitionModel.Recognition02;
+            string detectionModel = DetectionModel.Detection02;
 
             const string ImageUrlPrefix = "https://csdx.blob.core.windows.net/resources/Face/Images/";
             List<string> targetImageFileNames = new List<string>
@@ -35,7 +36,11 @@
             foreach (var targetImageFileName in targetImageFileNames)
             {
                 // Detect faces from target image url.
-                var faces = await Common.DetectFaces(client, $"{ImageUrlPrefix}{targetImageFileName}", recognitionModel: recognitionModel);
+                var faces = await Common.DetectFaces(
+                    client,
+                    $"{ImageUrlPrefix}{targetImageFileName}",
+                    recognitionModel: recognitionModel,
+                    detectionModel: detectionModel);
 
                 // Add detected faceId to targetFaceIds.
                 targetFaceIds.Add(faces[0].FaceId.Value);
@@ -45,7 +50,8 @@
             IList<DetectedFace> detectedFaces = await Common.DetectFaces(
                                                     client,
                                                     $"{ImageUrlPrefix}{sourceImageFileName}",
-                                                    recognitionModel: recognitionModel);
+                                                    recognitionModel: recognitionModel,
+                                                    detectionModel: detectionModel);
 
             // Find similar example of faceId to faceIds.
             IList<SimilarFace> similarResults = await client.Face.FindSimilarAsync(
@@ -76,6 +82,7 @@
 
             IFaceClient client = new FaceClient(new ApiKeyServiceClientCredentials(key)) { Endpoint = endpoint };
             string recognitionModel = RecognitionModel.Recognition02;
+            string detectionModel = DetectionModel.Detection02;
 
             const string ImageUrlPrefix = "https://csdx.blob.core.windows.net/resources/Face/Images/";
             List<string> targetImageFileNames = new List<string>
@@ -107,7 +114,8 @@
                 var faces = await client.FaceList.AddFaceFromUrlAsync(
                                 faceListId,
                                 $"{ImageUrlPrefix}{targetImageFileName}",
-                                targetImageFileName);
+                                targetImageFileName,
+                                detectionModel: detectionModel);
                 if (faces == null)
                 {
                     throw new Exception($"No face detected from image `{targetImageFileName}`.");
@@ -127,7 +135,8 @@
             IList<DetectedFace> detectedFaces = await Common.DetectFaces(
                                                     client,
                                                     $"{ImageUrlPrefix}{sourceImageFileName}",
-                                                    recognitionModel: recognitionModel);
+                                                    recognitionModel: recognitionModel,
+                                                    detectionModel: detectionModel);
 
             // Find similar example of faceId to face list.
             var similarResults = await client.Face.FindSimilarAsync(detectedFaces[0].FaceId.Value, faceListId);
@@ -160,6 +169,7 @@
 
             IFaceClient client = new FaceClient(new ApiKeyServiceClientCredentials(key)) { Endpoint = endpoint };
             string recognitionModel = RecognitionModel.Recognition02;
+            string detectionModel = DetectionModel.Detection02;
 
             const string ImageUrlPrefix = "https://csdx.blob.core.windows.net/resources/Face/Images/";
             List<string> targetImageFileNames = new List<string>
@@ -191,7 +201,8 @@
                 var faces = await client.LargeFaceList.AddFaceFromUrlAsync(
                                 largeFaceListId,
                                 $"{ImageUrlPrefix}{targetImageFileName}",
-                                targetImageFileName);
+                                targetImageFileName,
+                                detectionModel: detectionModel);
                 if (faces == null)
                 {
                     throw new Exception($"No face detected from image `{targetImageFileName}`.");
@@ -233,7 +244,8 @@
             IList<DetectedFace> detectedFaces = await Common.DetectFaces(
                                                     client,
                                                     $"{ImageUrlPrefix}{sourceImageFileName}",
-                                                    recognitionModel: recognitionModel);
+                                                    recognitionModel: recognitionModel,
+                                                    detectionModel: detectionModel);
 
             // Find similar example of faceId to large face list.
             var similarResults = await client.Face.FindSimilarAsync(

--- a/samples/Face/Group.cs
+++ b/samples/Face/Group.cs
@@ -14,6 +14,7 @@
 
             IFaceClient client = new FaceClient(new ApiKeyServiceClientCredentials(key)) { Endpoint = endpoint };
             string recognitionModel = RecognitionModel.Recognition02;
+            string detectionModel = DetectionModel.Detection02;
 
             const string ImageUrlPrefix = "https://csdx.blob.core.windows.net/resources/Face/Images/";
             List<string> imageFileNames = new List<string>
@@ -34,7 +35,8 @@
                 IList<DetectedFace> detectedFaces = await Common.DetectFaces(
                                                         client,
                                                         $"{ImageUrlPrefix}{imageFileName}",
-                                                        recognitionModel: recognitionModel);
+                                                        recognitionModel: recognitionModel,
+                                                        detectionModel: detectionModel);
 
                 // Add detected faceId to faceIds and faces.
                 faceIds.Add(detectedFaces[0].FaceId.Value);

--- a/samples/Face/Identify.cs
+++ b/samples/Face/Identify.cs
@@ -14,6 +14,7 @@
 
             IFaceClient client = new FaceClient(new ApiKeyServiceClientCredentials(key)) { Endpoint = endpoint };
             string recognitionModel = RecognitionModel.Recognition02;
+            string detectionModel = DetectionModel.Detection02;
 
             const string ImageUrlPrefix = "https://csdx.blob.core.windows.net/resources/Face/Images/";
             Dictionary<string, string[]> targetImageFileDictionary =
@@ -63,7 +64,8 @@
                                              personGroupId,
                                              person.PersonId,
                                              $"{ImageUrlPrefix}{targetImageFileName}",
-                                             targetImageFileName);
+                                             targetImageFileName,
+                                             detectionModel: detectionModel);
 
                     if (face == null)
                     {
@@ -99,7 +101,8 @@
             List<DetectedFace> detectedFaces = await Common.DetectFaces(
                                                    client,
                                                    $"{ImageUrlPrefix}{sourceImageFileName}",
-                                                   recognitionModel: recognitionModel);
+                                                   recognitionModel: recognitionModel,
+                                                   detectionModel: detectionModel);
 
             // Add detected faceId to sourceFaceIds.
             foreach (var detectedFace in detectedFaces)
@@ -140,6 +143,7 @@
 
             IFaceClient client = new FaceClient(new ApiKeyServiceClientCredentials(key)) { Endpoint = endpoint };
             string recognitionModel = RecognitionModel.Recognition02;
+            string detectionModel = DetectionModel.Detection02;
 
             const string ImageUrlPrefix = "https://csdx.blob.core.windows.net/resources/Face/Images/";
             Dictionary<string, string[]> targetImageFileDictionary =
@@ -188,7 +192,8 @@
                                              largePersonGroupId,
                                              person.PersonId,
                                              $"{ImageUrlPrefix}{targetImageFileName}",
-                                             targetImageFileName);
+                                             targetImageFileName,
+                                             detectionModel: detectionModel);
 
                     if (face == null)
                     {
@@ -224,7 +229,8 @@
             List<DetectedFace> detectedFaces = await Common.DetectFaces(
                                                    client,
                                                    $"{ImageUrlPrefix}{sourceImageFileName}",
-                                                   recognitionModel: recognitionModel);
+                                                   recognitionModel: recognitionModel,
+                                                   detectionModel: detectionModel);
 
             // Add detected faceIds to sourceFaceIds.
             foreach (var detectedFace in detectedFaces)

--- a/samples/Face/Microsoft.Azure.CognitiveServices.Samples.Face.csproj
+++ b/samples/Face/Microsoft.Azure.CognitiveServices.Samples.Face.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.Face" Version="2.4.0-preview" />
+    <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.Face" Version="2.5.0-preview.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/Face/Verify.cs
+++ b/samples/Face/Verify.cs
@@ -25,7 +25,7 @@
             foreach (var imageFileName in targetImageFileNames)
             {
                 // Detect faces from target image url.
-                List<DetectedFace> detectedFaces = await Common.DetectFaces(client, $"{ImageUrlPrefix}{imageFileName}", recognitionModel: recognitionModel);
+                List<DetectedFace> detectedFaces = await Common.DetectFaces(client, $"{ImageUrlPrefix}{imageFileName}", recognitionModel: recognitionModel, detectionModel: detectionModel);
                 targetFaceIds.Add(detectedFaces[0].FaceId.Value);
             }
 

--- a/samples/Face/Verify.cs
+++ b/samples/Face/Verify.cs
@@ -14,6 +14,7 @@
 
             IFaceClient client = new FaceClient(new ApiKeyServiceClientCredentials(key)) { Endpoint = endpoint };
             string recognitionModel = RecognitionModel.Recognition02;
+            string detectionModel = DetectionModel.Detection02;
 
             const string ImageUrlPrefix = "https://csdx.blob.core.windows.net/resources/Face/Images/";
             List<string> targetImageFileNames = new List<string> { "Family1-Dad1.jpg", "Family1-Dad2.jpg" };
@@ -32,14 +33,16 @@
             List<DetectedFace> detectedFaces1 = await Common.DetectFaces(
                                                     client,
                                                     $"{ImageUrlPrefix}{sourceImageFileName1}",
-                                                    recognitionModel: recognitionModel);
+                                                    recognitionModel: recognitionModel,
+                                                    detectionModel: detectionModel);
             Guid sourceFaceId1 = detectedFaces1[0].FaceId.Value;
 
             // Detect faces from source image file 2.
             List<DetectedFace> detectedFaces2 = await Common.DetectFaces(
                                                     client,
                                                     $"{ImageUrlPrefix}{sourceImageFileName2}",
-                                                    recognitionModel: recognitionModel);
+                                                    recognitionModel: recognitionModel,
+                                                    detectionModel: detectionModel);
             Guid sourceFaceId2 = detectedFaces2[0].FaceId.Value;
 
             // Verification example for faces of the same person.
@@ -68,6 +71,7 @@
 
             IFaceClient client = new FaceClient(new ApiKeyServiceClientCredentials(key)) { Endpoint = endpoint };
             string recognitionModel = RecognitionModel.Recognition02;
+            string detectionModel = DetectionModel.Detection02;
 
             const string ImageUrlPrefix = "https://csdx.blob.core.windows.net/resources/Face/Images/";
             List<string> targetImageFileNames = new List<string> { "Family1-Dad1.jpg", "Family1-Dad2.jpg" };
@@ -91,7 +95,8 @@
                                           personGroupId,
                                           p.PersonId,
                                           $"{ImageUrlPrefix}{targetImageFileName}",
-                                          targetImageFileName);
+                                          targetImageFileName,
+                                          detectionModel: detectionModel);
 
                 if (faces == null)
                 {
@@ -105,7 +110,8 @@
             List<DetectedFace> detectedFaces = await Common.DetectFaces(
                                                    client,
                                                    $"{ImageUrlPrefix}{sourceImageFileName1}",
-                                                   recognitionModel: recognitionModel);
+                                                   recognitionModel: recognitionModel,
+                                                   detectionModel: detectionModel);
             faceIds.Add(detectedFaces[0].FaceId.Value);
 
             // Verification example for faces of the same person.
@@ -132,6 +138,7 @@
 
             IFaceClient client = new FaceClient(new ApiKeyServiceClientCredentials(key)) { Endpoint = endpoint };
             string recognitionModel = RecognitionModel.Recognition02;
+            string detectionModel = DetectionModel.Detection02;
 
             const string ImageUrlPrefix = "https://csdx.blob.core.windows.net/resources/Face/Images/";
             List<string> targetImageFileNames = new List<string> { "Family1-Dad1.jpg", "Family1-Dad2.jpg" };
@@ -156,7 +163,8 @@
                                           largePersonGroupId,
                                           p.PersonId,
                                           $"{ImageUrlPrefix}{targetImageFileName}",
-                                          targetImageFileName);
+                                          targetImageFileName,
+                                          detectionModel: detectionModel);
                 if (faces == null)
                 {
                     throw new Exception($"No persisted face from image `{targetImageFileName}`.");
@@ -169,7 +177,8 @@
             List<DetectedFace> detectedfaces = await Common.DetectFaces(
                                                    client,
                                                    $"{ImageUrlPrefix}{sourceImageFileName1}",
-                                                   recognitionModel: recognitionModel);
+                                                   recognitionModel: recognitionModel,
+                                                   detectionModel: detectionModel);
             faceIds.Add(detectedfaces[0].FaceId.Value);
 
             // Verification example for faces of the same person.


### PR DESCRIPTION
* Update multiple recognition models.
* Update multiple recognition model test.
* Update FaceSDK nuget package.
* Update faceSDK to Cognitive-Services-Face-WPF.
* Update FaceSDK to FaceApiSnapshotSample.

## API Name (Kind)
`Face`

## Purpose
Update the samples to use Face's latest detection model: detection_02
