### PR TITLE
Typo fix in ModerateText Method

### DIFF
--- a/documentation-samples/quickstarts/ContentModerator/Program.cs
+++ b/documentation-samples/quickstarts/ContentModerator/Program.cs
@@ -243,7 +243,7 @@ namespace ContentModeratorQuickstart
 			byte[] textBytes = Encoding.UTF8.GetBytes(text);
 			MemoryStream stream = new MemoryStream(textBytes);
 
-			Console.WriteLine("Screening {0}...", outputFile);
+			Console.WriteLine("Screening {0}...", inputFile);
 			// Format text
 
 			// Save the moderation results to a file.


### PR DESCRIPTION
Changed to inputFile instead of outputFile in Console.WriteLine("Screening {0}...", outputFile);

Please use `[API Name] Brief description` as title.

## API Name (Kind)
`Face`, `TextAnalytics`, `ComputerVision`...

## Purpose
Describe the intention of the changes being proposed.
What problem does it solve or functionality does it add?

## Other Information
Add any other helpful information that may be needed here.