### PR TITLE
[CustomVision] Don't open the file twice.

### DIFF
--- a/CustomVision/ObjectDetection/Program.cs
+++ b/CustomVision/ObjectDetection/Program.cs
@@ -157,7 +157,7 @@ namespace ObjectDetection
             var imageFile = Path.Combine("Images", "test", "test_image.jpg");
             using (var stream = File.OpenRead(imageFile))
             {
-                var result = endpoint.DetectImage(project.Id, publishedModelName, File.OpenRead(imageFile));
+                var result = endpoint.DetectImage(project.Id, publishedModelName, stream);
 
                 // Loop over each prediction and write out the results
                 foreach (var c in result.Predictions)


### PR DESCRIPTION
## API Name (Kind)
CustomVision

## Purpose
Predicting an image is opening the file twice, updating code to only open the file once.

## Other Information
Fixes MicrosoftDocs/azure-docs#46887