### PR TITLE
Correcting error in DetectDomainSpecific() for local image

### DIFF
--- a/documentation-samples/quickstarts/ComputerVision/Program.cs
+++ b/documentation-samples/quickstarts/ComputerVision/Program.cs
@@ -522,8 +522,8 @@ namespace ComputerVisionQuickstart
                 // Display results.
                 var jsonLocal = JsonConvert.SerializeObject(resultsLocal.Result);
                 JObject resultJsonLocal = JObject.Parse(jsonLocal);
-                Console.WriteLine($"Celebrity detected: {resultJsonLocal["celebrities"][2]["name"]} " +
-                  $"with confidence {resultJsonLocal["celebrities"][2]["confidence"]}");
+                Console.WriteLine($"Celebrity detected: {resultJsonLocal["celebrities"][0]["name"]} " +
+                  $"with confidence {resultJsonLocal["celebrities"][0]["confidence"]}");
 
                 Console.WriteLine(resultJsonLocal);
             }


### PR DESCRIPTION
Please use `[API Name] Brief description` as title.

## API Name (Kind)
 `ComputerVision`

## Purpose
Unhandled exception seen while using DetectDomainSpecific() for local image as it is referring to print the response from JSON from incorrect reference

## Other Information
```
Console.WriteLine($"Landmark detected: {resultJsonUrl["landmarks"][2]["name"]} " +
              $"with confidence {resultJsonUrl["landmarks"][2]["confidence"]}.");
```

should be 

```
Console.WriteLine($"Landmark detected: {resultJsonUrl["landmarks"][0]["name"]} " +
              $"with confidence {resultJsonUrl["landmarks"][0]["confidence"]}.");
```