### PR TITLE
Bing Web Search SDK - Show how to add custom API endpoint

### DIFF
--- a/BingSearchv7/BingWebSearch/WebSearchSamples.cs
+++ b/BingSearchv7/BingWebSearch/WebSearchSamples.cs
@@ -14,7 +14,8 @@
         public static async void WebSearchResultTypesLookup(string subscriptionKey)
         {
             var client = new WebSearchClient(new ApiKeyServiceClientCredentials(subscriptionKey));
-           
+            // You might need to enter your custom endpoint from the Azure portal here
+            // client.Endpoint = "<Your Endpoint Here>";
             try
             {
                 var webData = await client.Web.SearchAsync(query: "Xbox");


### PR DESCRIPTION
You may need to specify a custom API endpoint issued to you when you create the search resource in the Azure portal

## API Name (Kind)
Bing Web Search SDK

## Purpose
 Show how to add custom API endpoint.  The code as is doesn't work if you run the client API call without specifying the custom API endpoint issued to you when you create the Azure resource

## Other Information
Simply shows how you can customize the API endpoint.  The addition is commented out.